### PR TITLE
Get rid of OutOfMemoryError when render large Bitmap

### DIFF
--- a/Movies/Movies.Android/MovieApplication.cs
+++ b/Movies/Movies.Android/MovieApplication.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+
+namespace Movies.Droid
+{
+    [Application(LargeHeap = true)]
+    public class MovieApplication : Application
+    {
+        public MovieApplication(IntPtr handle, JniHandleOwnership ownerShip) : base(handle, ownerShip)
+        {
+        }
+    }
+}

--- a/Movies/Movies.Android/Movies.Android.csproj
+++ b/Movies/Movies.Android/Movies.Android.csproj
@@ -146,6 +146,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
+    <Compile Include="MovieApplication.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
See https://stackoverflow.com/questions/41055393/xamarin-form-exception-heaps-size-and-outofmemoryerror